### PR TITLE
Upgrade 0.9.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ log = "0.4.17"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-pallet-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub mod pallet {
             FixedPointOperand, Percent, Saturating,
         },
         traits::{
-            fungibles::{Inspect, Transfer},
-            tokens::Balance,
+            fungibles::{Inspect, Mutate},
+            tokens::{Balance, Preservation},
         },
         PalletId,
     };
@@ -102,7 +102,7 @@ pub mod pallet {
                 &self.challenger,
                 &T::pallet_account(),
                 self.bet_amount,
-                false,
+                Preservation::Expendable,
             )?;
             Ok(())
         }
@@ -113,7 +113,7 @@ pub mod pallet {
                 &self.opponent,
                 &T::pallet_account(),
                 self.bet_amount,
-                false,
+                Preservation::Expendable,
             )?;
             Ok(())
         }
@@ -124,7 +124,7 @@ pub mod pallet {
                 &T::pallet_account(),
                 &self.challenger,
                 self.bet_amount,
-                false,
+                Preservation::Expendable,
             )?;
             Ok(())
         }
@@ -135,14 +135,14 @@ pub mod pallet {
                 &T::pallet_account(),
                 &self.challenger,
                 self.bet_amount,
-                false,
+                Preservation::Expendable,
             )?;
             T::Assets::transfer(
                 self.bet_asset_id,
                 &T::pallet_account(),
                 &self.opponent,
                 self.bet_amount,
-                false,
+                Preservation::Expendable,
             )?;
             Ok(())
         }
@@ -154,7 +154,7 @@ pub mod pallet {
                 &T::pallet_account(),
                 winner,
                 win_amount,
-                false,
+                Preservation::Expendable,
             )?;
             Ok(())
         }
@@ -170,14 +170,14 @@ pub mod pallet {
                 &T::pallet_account(),
                 janitor,
                 janitor_incentive,
-                false,
+                Preservation::Expendable,
             )?;
             T::Assets::transfer(
                 self.bet_asset_id,
                 &T::pallet_account(),
                 winner,
                 actual_prize,
-                false,
+                Preservation::Expendable,
             )?;
             Ok(())
         }
@@ -219,7 +219,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         type WeightInfo: WeightInfo;
         type Assets: Inspect<Self::AccountId, Balance = Self::AssetBalance>
-            + Transfer<Self::AccountId>;
+            + Mutate<Self::AccountId>;
         type AssetBalance: Balance
             + FixedPointOperand
             + MaxEncodedLen

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -89,8 +89,8 @@ impl pallet_balances::Config for Test {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type HoldIdentifier = ();
-    type MaxFreezes = ();
-    type MaxHolds = ();
+    type MaxFreezes = ConstU32<0>;
+    type MaxHolds = ConstU32<0>;
 }
 
 impl pallet_assets::Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -87,6 +87,10 @@ impl pallet_balances::Config for Test {
     type MaxLocks = ();
     type MaxReserves = ();
     type ReserveIdentifier = [u8; 8];
+    type FreezeIdentifier = ();
+    type HoldIdentifier = ();
+    type MaxFreezes = ();
+    type MaxHolds = ();
 }
 
 impl pallet_assets::Config for Test {


### PR DESCRIPTION
Upgrades the pallet to V0.9.42, the main changes are based on the modification to the balance_pallet and the fungibles traits as described [in this PR on substrate](https://github.com/paritytech/substrate/pull/12951).

The main change has to do with the removal of the `Transfer` trait which was merged into the `Mutate` trait and the inclusion/change of some parameters to some of the functions inside this trait.

closes #29 