### PR TITLE
Refactor UserMatches logic to improve UX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,10 +339,10 @@ pub mod pallet {
             <Matches<T>>::insert(match_id, new_match);
             // Insert the match id into the user's match list
             let mut user_matches = <UserMatches<T>>::take(challenger.clone());
-			user_matches
-				.try_push(match_id)
-				.map_err(|_| Error::<T>::TooManyMatchesPerUser)?;
-			<UserMatches<T>>::insert(challenger.clone(), user_matches);
+            user_matches
+                .try_push(match_id)
+                .map_err(|_| Error::<T>::TooManyMatchesPerUser)?;
+            <UserMatches<T>>::insert(challenger.clone(), user_matches);
 
             <MatchIdFromNonce<T>>::insert(nonce, match_id);
             Self::increment_nonce()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,8 @@ pub mod pallet {
     pub(super) type Matches<T: Config> = StorageMap<_, Twox64Concat, T::Hash, Match<T>>;
 
     #[pallet::storage]
-    #[pallet::getter(fn user_matches)]
-    pub(super) type UserMatches<T: Config> = StorageDoubleMap<
+    #[pallet::getter(fn player_matches)]
+    pub(super) type PlayerMatches<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,
         T::AccountId,
@@ -249,10 +249,6 @@ pub mod pallet {
 
         #[pallet::constant]
         type IncentiveShare: Get<u8>;
-
-        /// The maximum number matches per user.
-        #[pallet::constant]
-        type MaxMatchesPerUser: Get<u32>;
     }
 
     pub trait ConfigHelper: Config {
@@ -298,7 +294,6 @@ pub mod pallet {
         MatchNotOnGoing,
         MatchNotAbandoned,
         MoveNotExpired,
-        TooManyMatchesPerUser,
     }
 
     const MOVE_FEN_LENGTH: usize = 4;
@@ -339,7 +334,7 @@ pub mod pallet {
 
             let match_id = Self::match_id(challenger.clone(), opponent.clone(), nonce.clone());
             <Matches<T>>::insert(match_id, new_match);
-            <UserMatches<T>>::insert(challenger.clone(), match_id, ());
+            <PlayerMatches<T>>::insert(challenger.clone(), match_id, ());
             <MatchIdFromNonce<T>>::insert(nonce, match_id);
 
             Self::increment_nonce()?;
@@ -370,7 +365,7 @@ pub mod pallet {
             chess_match.abort_bet()?;
 
             <Matches<T>>::remove(match_id);
-            <UserMatches<T>>::remove(who.clone(), match_id);
+            <PlayerMatches<T>>::remove(who.clone(), match_id);
             <MatchIdFromNonce<T>>::remove(chess_match.nonce);
 
             Self::deposit_event(Event::MatchAborted(match_id));
@@ -398,7 +393,7 @@ pub mod pallet {
             chess_match.start = <frame_system::Pallet<T>>::block_number();
             <Matches<T>>::insert(match_id, chess_match);
 
-            <UserMatches<T>>::insert(who, match_id, ());
+            <PlayerMatches<T>>::insert(who, match_id, ());
 
             Self::deposit_event(Event::MatchStarted(match_id));
 
@@ -479,8 +474,8 @@ pub mod pallet {
 
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
-                <UserMatches<T>>::remove(chess_match.challenger.clone(), match_id);
-                <UserMatches<T>>::remove(chess_match.opponent, match_id);
+                <PlayerMatches<T>>::remove(chess_match.challenger.clone(), match_id);
+                <PlayerMatches<T>>::remove(chess_match.opponent, match_id);
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else if chess_match.state == MatchState::Drawn {
                 Self::deposit_event(Event::MatchDrawn(match_id, chess_match.board.clone()));
@@ -490,8 +485,8 @@ pub mod pallet {
 
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
-                <UserMatches<T>>::remove(chess_match.challenger.clone(), match_id);
-                <UserMatches<T>>::remove(chess_match.opponent, match_id);
+                <PlayerMatches<T>>::remove(chess_match.challenger.clone(), match_id);
+                <PlayerMatches<T>>::remove(chess_match.opponent, match_id);
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else {
                 // match still ongoing, update on-chain board
@@ -564,8 +559,8 @@ pub mod pallet {
             }
 
             <Matches<T>>::remove(match_id);
-            <UserMatches<T>>::remove(chess_match.challenger.clone(), match_id);
-            <UserMatches<T>>::remove(chess_match.opponent, match_id);
+            <PlayerMatches<T>>::remove(chess_match.challenger.clone(), match_id);
+            <PlayerMatches<T>>::remove(chess_match.opponent, match_id);
             <MatchIdFromNonce<T>>::remove(chess_match.nonce);
 
             Ok(())
@@ -642,14 +637,14 @@ pub mod pallet {
             if chess_match.state == MatchState::Won {
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
-                <UserMatches<T>>::remove(chess_match.challenger.clone(), match_id);
-                <UserMatches<T>>::remove(chess_match.opponent, match_id);
+                <PlayerMatches<T>>::remove(chess_match.challenger.clone(), match_id);
+                <PlayerMatches<T>>::remove(chess_match.opponent, match_id);
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else if chess_match.state == MatchState::Drawn {
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
-                <UserMatches<T>>::remove(chess_match.challenger.clone(), match_id);
-                <UserMatches<T>>::remove(chess_match.opponent, match_id);
+                <PlayerMatches<T>>::remove(chess_match.challenger.clone(), match_id);
+                <PlayerMatches<T>>::remove(chess_match.opponent, match_id);
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else {
                 // match still ongoing, update on-chain board

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,15 +206,8 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn player_matches)]
-    pub(super) type PlayerMatches<T: Config> = StorageDoubleMap<
-        _,
-        Twox64Concat,
-        T::AccountId,
-        Twox64Concat, 
-        T::Hash,
-        (),
-        OptionQuery,
-    >;
+    pub(super) type PlayerMatches<T: Config> =
+        StorageDoubleMap<_, Twox64Concat, T::AccountId, Twox64Concat, T::Hash, (), OptionQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn chess_match_id_from_nonce)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,7 @@ pub mod pallet {
             <Matches<T>>::remove(match_id);
             // Remove the match id from the user's match list
             let mut user_matches = <UserMatches<T>>::take(who.clone());
+            user_matches.sort();
             let pos = user_matches
 				.binary_search(&match_id)
 				.ok().ok_or(Error::<T>::NonExistentMatch)?;
@@ -487,20 +488,22 @@ pub mod pallet {
 
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
-                // Remove the match id from the user's challenger match list
-                let mut user_matches = <UserMatches<T>>::take(chess_match.challenger.clone());
-                let pos = user_matches
+                 // Remove the match id from the user's challenger match list
+                let mut user_matches_challenger = <UserMatches<T>>::take(chess_match.challenger.clone());
+                user_matches_challenger.sort();
+                let pos = user_matches_challenger
                     .binary_search(&match_id)
                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                user_matches.remove(pos);
-                <UserMatches<T>>::insert(chess_match.challenger, user_matches);
+                    user_matches_challenger.remove(pos);
+                <UserMatches<T>>::insert(chess_match.challenger, user_matches_challenger);
                 // Remove the match id from the user's opponent match list
-                let mut user_matches = <UserMatches<T>>::take(chess_match.opponent.clone());
-                let pos = user_matches
+                let mut user_matches_opponent = <UserMatches<T>>::take(chess_match.opponent.clone());
+                user_matches_opponent.sort();
+                let pos = user_matches_opponent
                     .binary_search(&match_id)
                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                user_matches.remove(pos);
-                <UserMatches<T>>::insert(chess_match.opponent, user_matches);
+                    user_matches_opponent.remove(pos);
+                <UserMatches<T>>::insert(chess_match.opponent, user_matches_opponent);
 
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else if chess_match.state == MatchState::Drawn {
@@ -512,20 +515,22 @@ pub mod pallet {
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
 
-                // Remove the match id from the user's challenger match list
-                let mut user_matches = <UserMatches<T>>::take(chess_match.challenger.clone());
-                let pos = user_matches
+                 // Remove the match id from the user's challenger match list
+                let mut user_matches_challenger = <UserMatches<T>>::take(chess_match.challenger.clone());
+                user_matches_challenger.sort();
+                let pos = user_matches_challenger
                     .binary_search(&match_id)
                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                user_matches.remove(pos);
-                <UserMatches<T>>::insert(chess_match.challenger, user_matches);
+                    user_matches_challenger.remove(pos);
+                <UserMatches<T>>::insert(chess_match.challenger, user_matches_challenger);
                 // Remove the match id from the user's opponent match list
-                let mut user_matches = <UserMatches<T>>::take(chess_match.opponent.clone());
-                let pos = user_matches
+                let mut user_matches_opponent = <UserMatches<T>>::take(chess_match.opponent.clone());
+                user_matches_opponent.sort();
+                let pos = user_matches_opponent
                     .binary_search(&match_id)
                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                user_matches.remove(pos);
-                <UserMatches<T>>::insert(chess_match.opponent, user_matches);
+                    user_matches_opponent.remove(pos);
+                <UserMatches<T>>::insert(chess_match.opponent, user_matches_opponent);
 
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else {
@@ -601,19 +606,21 @@ pub mod pallet {
             <Matches<T>>::remove(match_id);
 
              // Remove the match id from the user's challenger match list
-             let mut user_matches = <UserMatches<T>>::take(chess_match.challenger.clone());
-             let pos = user_matches
+             let mut user_matches_challenger = <UserMatches<T>>::take(chess_match.challenger.clone());
+             user_matches_challenger.sort();
+             let pos = user_matches_challenger
                  .binary_search(&match_id)
                  .ok().ok_or(Error::<T>::NonExistentMatch)?;
-             user_matches.remove(pos);
-             <UserMatches<T>>::insert(chess_match.challenger, user_matches);
+                user_matches_challenger.remove(pos);
+             <UserMatches<T>>::insert(chess_match.challenger, user_matches_challenger);
              // Remove the match id from the user's opponent match list
-             let mut user_matches = <UserMatches<T>>::take(chess_match.opponent.clone());
-             let pos = user_matches
+             let mut user_matches_opponent = <UserMatches<T>>::take(chess_match.opponent.clone());
+             user_matches_opponent.sort();
+             let pos = user_matches_opponent
                  .binary_search(&match_id)
                  .ok().ok_or(Error::<T>::NonExistentMatch)?;
-             user_matches.remove(pos);
-             <UserMatches<T>>::insert(chess_match.opponent, user_matches);
+                user_matches_opponent.remove(pos);
+             <UserMatches<T>>::insert(chess_match.opponent, user_matches_opponent);
 
             <MatchIdFromNonce<T>>::remove(chess_match.nonce);
 
@@ -692,41 +699,45 @@ pub mod pallet {
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
 
-                 // Remove the match id from the user's challenger match list
-                 let mut user_matches = <UserMatches<T>>::take(chess_match.challenger.clone());
-                 let pos = user_matches
-                     .binary_search(&match_id)
-                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                 user_matches.remove(pos);
-                 <UserMatches<T>>::insert(chess_match.challenger, user_matches);
-                 // Remove the match id from the user's opponent match list
-                 let mut user_matches = <UserMatches<T>>::take(chess_match.opponent.clone());
-                 let pos = user_matches
-                     .binary_search(&match_id)
-                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                 user_matches.remove(pos);
-                 <UserMatches<T>>::insert(chess_match.opponent, user_matches);
+                  // Remove the match id from the user's challenger match list
+                let mut user_matches_challenger = <UserMatches<T>>::take(chess_match.challenger.clone());
+                user_matches_challenger.sort();
+                let pos = user_matches_challenger
+                    .binary_search(&match_id)
+                    .ok().ok_or(Error::<T>::NonExistentMatch)?;
+                    user_matches_challenger.remove(pos);
+                <UserMatches<T>>::insert(chess_match.challenger, user_matches_challenger);
+                // Remove the match id from the user's opponent match list
+                let mut user_matches_opponent = <UserMatches<T>>::take(chess_match.opponent.clone());
+                user_matches_opponent.sort();
+                let pos = user_matches_opponent
+                    .binary_search(&match_id)
+                    .ok().ok_or(Error::<T>::NonExistentMatch)?;
+                    user_matches_opponent.remove(pos);
+                <UserMatches<T>>::insert(chess_match.opponent, user_matches_opponent);
 
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else if chess_match.state == MatchState::Drawn {
                 // match is over, clean up storage
                 <Matches<T>>::remove(match_id);
 
-                 // Remove the match id from the user's challenger match list
-                 let mut user_matches = <UserMatches<T>>::take(chess_match.challenger.clone());
-                 let pos = user_matches
-                     .binary_search(&match_id)
-                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                 user_matches.remove(pos);
-                 <UserMatches<T>>::insert(chess_match.challenger, user_matches);
-                 // Remove the match id from the user's opponent match list
-                 let mut user_matches = <UserMatches<T>>::take(chess_match.opponent.clone());
-                 let pos = user_matches
-                     .binary_search(&match_id)
-                     .ok().ok_or(Error::<T>::NonExistentMatch)?;
-                 user_matches.remove(pos);
-                 <UserMatches<T>>::insert(chess_match.opponent, user_matches);
-                 
+                  // Remove the match id from the user's challenger match list
+                let mut user_matches_challenger = <UserMatches<T>>::take(chess_match.challenger.clone());
+                user_matches_challenger.sort();
+                let pos = user_matches_challenger
+                    .binary_search(&match_id)
+                    .ok().ok_or(Error::<T>::NonExistentMatch)?;
+                    user_matches_challenger.remove(pos);
+                <UserMatches<T>>::insert(chess_match.challenger, user_matches_challenger);
+                // Remove the match id from the user's opponent match list
+                let mut user_matches_opponent = <UserMatches<T>>::take(chess_match.opponent.clone());
+                user_matches_opponent.sort();
+                let pos = user_matches_opponent
+                    .binary_search(&match_id)
+                    .ok().ok_or(Error::<T>::NonExistentMatch)?;
+                    user_matches_opponent.remove(pos);
+                <UserMatches<T>>::insert(chess_match.opponent, user_matches_opponent);
+
                 <MatchIdFromNonce<T>>::remove(chess_match.nonce);
             } else {
                 // match still ongoing, update on-chain board

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,13 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn user_matches)]
-    pub(super) type UserMatches<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, BoundedVec<T::Hash, T::MaxMatchesPerUser>, ValueQuery>;
+    pub(super) type UserMatches<T: Config> = StorageMap<
+        _,
+        Twox64Concat,
+        T::AccountId,
+        BoundedVec<T::Hash, T::MaxMatchesPerUser>,
+        ValueQuery,
+    >;
 
     #[pallet::storage]
     #[pallet::getter(fn chess_match_id_from_nonce)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,7 @@ pub mod pallet {
             let match_id = Self::match_id(challenger.clone(), opponent.clone(), nonce.clone());
             <Matches<T>>::insert(match_id, new_match);
             <PlayerMatches<T>>::insert(challenger.clone(), match_id, ());
+            <PlayerMatches<T>>::insert(opponent.clone(), match_id, ());
             <MatchIdFromNonce<T>>::insert(nonce, match_id);
 
             Self::increment_nonce()?;
@@ -357,6 +358,7 @@ pub mod pallet {
 
             <Matches<T>>::remove(match_id);
             <PlayerMatches<T>>::remove(who.clone(), match_id);
+            <PlayerMatches<T>>::remove(chess_match.opponent, match_id);
             <MatchIdFromNonce<T>>::remove(chess_match.nonce);
 
             Self::deposit_event(Event::MatchAborted(match_id));
@@ -383,8 +385,6 @@ pub mod pallet {
             chess_match.state = MatchState::OnGoing(NextMove::Whites);
             chess_match.start = <frame_system::Pallet<T>>::block_number();
             <Matches<T>>::insert(match_id, chess_match);
-
-            <PlayerMatches<T>>::insert(who, match_id, ());
 
             Self::deposit_event(Event::MatchStarted(match_id));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,8 +243,8 @@ pub mod pallet {
         type IncentiveShare: Get<u8>;
 
         /// The maximum number matches per user.
-		#[pallet::constant]
-		type MaxMatchesPerUser: Get<u32>;
+        #[pallet::constant]
+        type MaxMatchesPerUser: Get<u32>;
     }
 
     pub trait ConfigHelper: Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod pallet {
     use crate::WeightInfo;
     use cozy_chess::{Board, Color, GameStatus, Move};
     use frame_support::{
-        pallet_prelude::{DispatchResult, *, ValueQuery},
+        pallet_prelude::{DispatchResult, ValueQuery, *},
         sp_runtime::{
             traits::{AccountIdConversion, Hash},
             FixedPointOperand, Percent, Saturating,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -62,7 +62,6 @@ parameter_types! {
     pub const DailyPeriod: u64 = 14400;
     pub const ChessPalletId: PalletId = PalletId(*b"subchess");
     pub const IncentiveShare: u8 = 10; // janitor gets 10% of the prize
-    pub const MaxMatchesPerUser: u32 = 100;
 }
 
 impl pallet_chess::Config for Test {
@@ -76,7 +75,6 @@ impl pallet_chess::Config for Test {
     type RapidPeriod = RapidPeriod;
     type DailyPeriod = DailyPeriod;
     type IncentiveShare = IncentiveShare;
-    type MaxMatchesPerUser = MaxMatchesPerUser;
 }
 
 impl pallet_balances::Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -107,6 +107,7 @@ impl pallet_assets::Config for Test {
     type WeightInfo = ();
     type Extra = ();
     type RemoveItemsLimit = ConstU32<5>;
+    type CallbackHandle = ();
 }
 
 pub const ASSET_ID: u32 = 200u32;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -62,6 +62,7 @@ parameter_types! {
     pub const DailyPeriod: u64 = 14400;
     pub const ChessPalletId: PalletId = PalletId(*b"subchess");
     pub const IncentiveShare: u8 = 10; // janitor gets 10% of the prize
+    pub const MaxMatchesPerUser: u32 = 100;
 }
 
 impl pallet_chess::Config for Test {
@@ -75,6 +76,7 @@ impl pallet_chess::Config for Test {
     type RapidPeriod = RapidPeriod;
     type DailyPeriod = DailyPeriod;
     type IncentiveShare = IncentiveShare;
+    type MaxMatchesPerUser = MaxMatchesPerUser;
 }
 
 impl pallet_balances::Config for Test {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -600,7 +600,7 @@ fn get_player_matches_works() {
 
         let match_id = Chess::chess_match_id_from_nonce(0).unwrap();
         let mut alice_matches = PlayerMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
-        let mut bob_matches =  PlayerMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
+        let mut bob_matches = PlayerMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
 
         assert_eq!(alice_matches[0], match_id);
         assert_eq!(bob_matches.len(), 0);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -603,7 +603,7 @@ fn get_player_matches_works() {
         let mut bob_matches = PlayerMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
 
         assert_eq!(alice_matches[0], match_id);
-        assert_eq!(bob_matches.len(), 0);
+        assert_eq!(bob_matches[0], match_id);
 
         assert_ok!(Chess::join_match(RuntimeOrigin::signed(bob), match_id));
         assert_ok!(Chess::create_match(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, Config, Error, Event, MatchState, MatchStyle, NextMove, UserMatches};
+use crate::{mock::*, Config, Error, Event, MatchState, MatchStyle, NextMove, PlayerMatches};
 use cozy_chess::Board;
 use frame_benchmarking::account;
 use frame_support::{assert_noop, assert_ok};
@@ -581,7 +581,7 @@ fn janitor_incentive_works() {
 }
 
 #[test]
-fn get_user_matches_works() {
+fn get_player_matches_works() {
     new_test_ext().execute_with(|| {
         let alice = account("Alice", 0, 0);
         let bob = account("Bob", 0, 1);
@@ -599,8 +599,8 @@ fn get_user_matches_works() {
         ));
 
         let match_id = Chess::chess_match_id_from_nonce(0).unwrap();
-        let mut alice_matches = UserMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
-        let mut bob_matches =  UserMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
+        let mut alice_matches = PlayerMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
+        let mut bob_matches =  PlayerMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
 
         assert_eq!(alice_matches[0], match_id);
         assert_eq!(bob_matches.len(), 0);
@@ -615,8 +615,8 @@ fn get_user_matches_works() {
         ));
         let new_match_id = Chess::chess_match_id_from_nonce(1).unwrap();
 
-        alice_matches = UserMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
-        bob_matches = UserMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
+        alice_matches = PlayerMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
+        bob_matches = PlayerMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
 
         assert_eq!(alice_matches[0], match_id);
         assert_eq!(alice_matches[1], new_match_id);
@@ -632,8 +632,8 @@ fn get_user_matches_works() {
             match_id
         ));
 
-        alice_matches = UserMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
-        bob_matches = UserMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
+        alice_matches = PlayerMatches::<Test>::iter_key_prefix(alice).collect::<Vec<_>>();
+        bob_matches = PlayerMatches::<Test>::iter_key_prefix(bob).collect::<Vec<_>>();
         assert_eq!(alice_matches[0], new_match_id);
         assert_eq!(bob_matches.len(), 0);
     });


### PR DESCRIPTION
In my previous PR https://github.com/SubstrateChess/pallet-chess/pull/24 we create a new storage UserMatches to allow a frontend app to query only the list of matches for an user.

I'd like to refactor that a bit, adding the match in both storages the opponent and the challenger when a match is created. This makes sense to show in the frontend the list of your ongoing matches and the matches you have been challenged to accept it directly, instead of having to know the `match_id`.