### PR TITLE
Extend unit testing for elo-ranking

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -147,6 +147,16 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
                 frame_benchmarking::account("Bob", 0, 1),
                 asset_min_balance * 100,
             ),
+            (
+                asset_id,
+                frame_benchmarking::account("Charlie", 0, 2),
+                asset_min_balance * 100,
+            ),
+            (
+                asset_id,
+                frame_benchmarking::account("Dave", 0, 3),
+                asset_min_balance * 100,
+            ),
         ],
     }
     .assimilate_storage(&mut storage)
@@ -156,6 +166,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         elo: vec![
             (frame_benchmarking::account("Alice", 0, 0), 2000),
             (frame_benchmarking::account("Bob", 0, 1), 2400),
+            (frame_benchmarking::account("Charlie", 0, 2), 1000),
+            (frame_benchmarking::account("Dave", 0, 3), 1000),
         ],
     }
     .assimilate_storage(&mut storage)

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -147,16 +147,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
                 frame_benchmarking::account("Bob", 0, 1),
                 asset_min_balance * 100,
             ),
-            (
-                asset_id,
-                frame_benchmarking::account("Charlie", 0, 2),
-                asset_min_balance * 100,
-            ),
-            (
-                asset_id,
-                frame_benchmarking::account("Dave", 0, 3),
-                asset_min_balance * 100,
-            ),
         ],
     }
     .assimilate_storage(&mut storage)
@@ -166,8 +156,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
         elo: vec![
             (frame_benchmarking::account("Alice", 0, 0), 2000),
             (frame_benchmarking::account("Bob", 0, 1), 2400),
-            (frame_benchmarking::account("Charlie", 0, 2), 1000),
-            (frame_benchmarking::account("Dave", 0, 3), 1000),
         ],
     }
     .assimilate_storage(&mut storage)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -534,18 +534,18 @@ fn check_elo_stronger_looses() {
 }
 
 #[test]
-fn check_elo_player_draw() {
+fn check_elo_player_draws() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
-        let charlie: u64 = account("Charlie", 0, 2);
-        let dave:u64  = account("Dave", 0, 3);
+        let alice = account("Alice", 0, 0);
+        let bob = account("Bob", 0, 1);
 
         let bet_asset_id = AssetId::get();
         let bet_amount = AssetMinBalance::get() * 5;
 
         assert_ok!(Chess::create_match(
-            RuntimeOrigin::signed(charlie),
-            dave,
+            RuntimeOrigin::signed(bob),
+            alice,
             MatchStyle::Bullet,
             bet_asset_id,
             bet_amount
@@ -553,11 +553,11 @@ fn check_elo_player_draw() {
 
         let match_id = Chess::chess_match_id_from_nonce(0).unwrap();
 
-        assert_ok!(Chess::join_match(RuntimeOrigin::signed(dave), match_id));
+        assert_ok!(Chess::join_match(RuntimeOrigin::signed(alice), match_id));
 
         // check elo before the match finishes
-        assert_eq!(Chess::player_elo(charlie), 1000);
-        assert_eq!(Chess::player_elo(dave), 1000);
+        assert_eq!(Chess::player_elo(alice), 2000);
+        assert_eq!(Chess::player_elo(bob), 2400);
 
         assert_ok!(Chess::force_board_state(
             match_id,
@@ -565,15 +565,15 @@ fn check_elo_player_draw() {
         ));
         // this move forces draws
         assert_ok!(Chess::make_move(
-            RuntimeOrigin::signed(charlie),
+            RuntimeOrigin::signed(bob),
             match_id,
             "a2f2".into()
         ));
         assert_eq!(Chess::chess_matches(match_id), None);
 
         // check the elo after the match is complete
-        assert_eq!(Chess::player_elo(charlie), 1000);
-        assert_eq!(Chess::player_elo(dave), 1000);
+        assert_eq!(Chess::player_elo(alice), 2013);
+        assert_eq!(Chess::player_elo(bob), 2387);
     });
 }
 
@@ -620,7 +620,7 @@ fn check_elo_stronger_abandon() {
             System::block_number() + <Test as Config>::BulletPeriod::get() + 1,
         );
 
-        // Bob abandom, alice claims victory 
+        // Bob abandoned, alice claims victory 
         assert_ok!(Chess::clear_abandoned_match(
             RuntimeOrigin::signed(alice),
             match_id

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -620,7 +620,7 @@ fn check_elo_stronger_abandon() {
             System::block_number() + <Test as Config>::BulletPeriod::get() + 1,
         );
 
-        // Bob abandoned, alice claims victory 
+        // Bob abandoned, alice claims victory
         assert_ok!(Chess::clear_abandoned_match(
             RuntimeOrigin::signed(alice),
             match_id
@@ -633,7 +633,6 @@ fn check_elo_stronger_abandon() {
         assert_eq!(Chess::player_elo(bob), 2371);
     });
 }
-
 
 const BOARD_STATE: &str = "Q7/5Q2/8/8/3k4/6P1/6BP/7K b - - 0 67";
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -534,7 +534,51 @@ fn check_elo_stronger_looses() {
 }
 
 #[test]
-fn check_elo_player_aborts() {
+fn check_elo_player_draw() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        let charlie: u64 = account("Charlie", 0, 2);
+        let dave:u64  = account("Dave", 0, 3);
+
+        let bet_asset_id = AssetId::get();
+        let bet_amount = AssetMinBalance::get() * 5;
+
+        assert_ok!(Chess::create_match(
+            RuntimeOrigin::signed(charlie),
+            dave,
+            MatchStyle::Bullet,
+            bet_asset_id,
+            bet_amount
+        ));
+
+        let match_id = Chess::chess_match_id_from_nonce(0).unwrap();
+
+        assert_ok!(Chess::join_match(RuntimeOrigin::signed(dave), match_id));
+
+        // check elo before the match finishes
+        assert_eq!(Chess::player_elo(charlie), 1000);
+        assert_eq!(Chess::player_elo(dave), 1000);
+
+        assert_ok!(Chess::force_board_state(
+            match_id,
+            "8/8/8/8/8/5K2/Q7/7k w - - 1 68".into()
+        ));
+        // this move forces draws
+        assert_ok!(Chess::make_move(
+            RuntimeOrigin::signed(charlie),
+            match_id,
+            "a2f2".into()
+        ));
+        assert_eq!(Chess::chess_matches(match_id), None);
+
+        // check the elo after the match is complete
+        assert_eq!(Chess::player_elo(charlie), 1000);
+        assert_eq!(Chess::player_elo(dave), 1000);
+    });
+}
+
+#[test]
+fn check_elo_stronger_abandon() {
     new_test_ext().execute_with(|| {
         System::set_block_number(1);
 
@@ -560,23 +604,36 @@ fn check_elo_player_aborts() {
         assert_eq!(Chess::player_elo(alice), 2000);
         assert_eq!(Chess::player_elo(bob), 2400);
 
-        assert_ok!(Chess::force_board_state(
-            match_id,
-            "8/8/8/8/8/5K2/Q7/7k w - - 1 68".into()
-        ));
-        // this move forces draws
         assert_ok!(Chess::make_move(
             RuntimeOrigin::signed(bob),
             match_id,
-            "a2f2".into()
+            "f2f3".into()
         ));
+        assert_ok!(Chess::make_move(
+            RuntimeOrigin::signed(alice),
+            match_id,
+            "e7e5".into()
+        ));
+
+        // advance the block number to the point where bob's time-to-move is expired
+        System::set_block_number(
+            System::block_number() + <Test as Config>::BulletPeriod::get() + 1,
+        );
+
+        // Bob abandom, alice claims victory 
+        assert_ok!(Chess::clear_abandoned_match(
+            RuntimeOrigin::signed(alice),
+            match_id
+        ));
+
         assert_eq!(Chess::chess_matches(match_id), None);
 
-        // check the elo after the match is complete
-        assert_eq!(Chess::player_elo(alice), 2013);
-        assert_eq!(Chess::player_elo(bob), 2387);
+        // check the elo after match is complete
+        assert_eq!(Chess::player_elo(alice), 2029);
+        assert_eq!(Chess::player_elo(bob), 2371);
     });
 }
+
 
 const BOARD_STATE: &str = "Q7/5Q2/8/8/3k4/6P1/6BP/7K b - - 0 67";
 


### PR DESCRIPTION
I changed the name of the test `check_elo_player_aborts` with `check_elo_player_draw` because what is actually testing is the scenario of a draw (I change the players ELO ranking too, but just for testing purposes).

I add a test `check_elo_stronger_abandon` where the stronger player abandon and therefore loses to see if in case of abandom the ELO ranking is updating property too.